### PR TITLE
Fixes #6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ terraform/.terraform
 .terraform.lock*
 .terraform*
 terraform.tfstate
+terraform/secret.tfvars

--- a/terraform/securitygroups.tf
+++ b/terraform/securitygroups.tf
@@ -1,3 +1,7 @@
+data "aws_prefix_list" "internal" {
+  prefix_list_id = var.prefix_corp_id
+}
+
 resource "aws_security_group" "external_access" {
   name        = "External Access"
   description = "Allow access from local network"
@@ -17,6 +21,16 @@ resource "aws_security_group_rule" "local_ip" {
 
 }
 
+resource "aws_security_group_rule" "local_corp" {
+  type              = "ingress"
+  description       = "Access from Corp"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "all"
+  prefix_list_ids   = ["${data.aws_prefix_list.internal.id}"]
+  security_group_id = aws_security_group.external_access.id
+
+}
 
 resource "aws_security_group_rule" "outbound" {
   type              = "egress"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,10 +4,20 @@ variable "public_subnets" { type = list(any) }
 variable "azs" { type = list(any) }
 variable "iam_role" { default = "DemoInstanceRole" }
 variable "hosted_zone" { type = string }
-variable "local_ip" { type = string }
+
+variable "prefix_corp_id" {
+    type = string
+    sensitive = true
+}
+
+variable "local_ip" {
+    type = string
+    sensitive = true
+}
 
 variable "dev_instance_dns" {
   type = string
+  sensitive = true
 }
 
 variable "tags_mgmt" {


### PR DESCRIPTION
Doesn't really need to accept multiple IPs, just a prefix list and local
IP. This has been changed because `prefix_list_ids` are actually a
built-in for the security_group resource.

Still dependent on https://github.com/hashicorp/terraform/issues/16065,
I had to manually go in and delete the security group, which requires
removing it from all instances. This is compeltely non-viable option for
a production environment unfortunately, as such, I will need to evaluate
the other way that Terraform can handle security groups (e.g. inline
security group rules, maybe?).

Unrelated to this commit, but created a secrets.tfvars for storing
sensitive variables. That's been added to gitignore.